### PR TITLE
Fix selector deprecations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "newbound-dark-syntax",
   "theme": "syntax",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A highly legible, medium contrast, dark syntax theme for Atom",
   "keywords": [
     "syntax",

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,4 +1,4 @@
-atom-text-editor, :host {
+atom-text-editor {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 
@@ -70,12 +70,12 @@ atom-text-editor, :host {
     background-color: fadeout(@base0D, 92%);
   }
 
-  .search-results .marker .region {
+  .search-results .syntax--marker .region {
     background-color: transparent;
     border: 1px solid @syntax-result-marker-color;
   }
 
-  .search-results .marker.current-result .region {
+  .search-results .syntax--marker.current-result .region {
     border: 1px solid @syntax-result-marker-color-selected;
   }
 }

--- a/styles/language.less
+++ b/styles/language.less
@@ -1,219 +1,214 @@
 // Default language syntax highlighting
 
-.comment {
+.syntax--comment {
   color: @base04;
 }
 
-.keyword {
+.syntax--keyword {
   color: @base0D;
 
-  &.control {
+  &.syntax--control {
     color: @base0E;
   }
 
-  &.operator {
+  &.syntax--operator {
     color: @base05;
   }
 
-  &.other.special-method {
+  &.syntax--other.syntax--special-method {
     color: @base0D;
   }
 
-  &.other.unit {
+  &.syntax--other.syntax--unit {
     color: @base06;
   }
 }
 
-.constant {
+.syntax--constant {
   color: @base09;
 
-  &.character.escape {
+  &.syntax--character.syntax--escape {
     color: @base0C;
   }
 
-  &.numeric {
+  &.syntax--numeric {
     color: @base09;
   }
 
-  &.other.color {
+  &.syntax--other.syntax--color {
     color: @base0C;
   }
 
-  &.other.symbol {
+  &.syntax--other.syntax--symbol {
     color: @base0B;
   }
 }
 
-.variable {
+.syntax--variable {
   color: @base08;
 
-  &.variable.interpolation {
+  &.syntax--variable.syntax--interpolation {
     color: @base0F;
   }
 
-  &.parameter.function {
+  &.syntax--parameter.syntax--function {
     color: @base05;
   }
 }
 
-.invalid.illegal {
+.syntax--invalid.syntax--illegal {
   color: @base07;
   background-color: @base08;
 }
 
-.string {
+.syntax--string {
   color: @base0B;
 
-  &.regexp {
+  &.syntax--regexp {
     color: @base0C;
 
-    .source.ruby.embedded {
+    .syntax--source.syntax--ruby.syntax--embedded {
       color: @base09;
     }
   }
 
-  &.other.link {
+  &.syntax--other.syntax--link {
     color: @base08;
   }
 }
 
-.punctuation {
-  &.definition {
-    &.comment {
+.syntax--punctuation {
+  &.syntax--definition {
+    &.syntax--comment {
       color: @base04;
     }
 
-    &.string,
-    &.variable,
-    &.parameters,
-    &.array {
+    &.syntax--string,
+    &.syntax--variable,
+    &.syntax--parameters,
+    &.syntax--array {
       color: @base05;
     }
 
-    &.entity {
+    &.syntax--entity {
       color: @base0D;
     }
   }
 
-  &.section.embedded {
+  &.syntax--section.syntax--embedded {
     color: @base0F;
   }
 }
 
-.support {
-  &.class {
+.syntax--support {
+  &.syntax--class {
     color: @base0A;
   }
 
-  &.function  {
+  &.syntax--function  {
     color: @base0C;
 
-    &.any-method {
+    &.syntax--any-method {
       color: @base0D;
     }
   }
 }
 
-.entity {
-  &.name.function {
+.syntax--entity {
+  &.syntax--name.syntax--function {
     color: @base0D;
   }
-  &.name.type {
+  &.syntax--name.syntax--type {
     color: @base0A;
   }
 
-  &.other.inherited-class {
+  &.syntax--other.syntax--inherited-class {
     color: @base0B;
   }
 
-  &.name.class,
-  &.name.type.class {
+  &.syntax--name.syntax--class,
+  &.syntax--name.syntax--type.syntax--class {
     color: @base0A;
   }
 
-  &.name.section {
+  &.syntax--name.syntax--section {
     color: @base0D;
   }
 
-  &.name.tag {
+  &.syntax--name.syntax--tag {
     color: @base08;
   }
 
-  &.other.attribute-name {
+  &.syntax--other.syntax--attribute-name {
     color: @base09;
 
-    &.id {
+    &.syntax--id {
       color: @base0D;
     }
   }
 }
 
-.meta {
-  &.class {
+.syntax--meta {
+  &.syntax--class {
     color: @base0A;
   }
 
-  &.link {
+  &.syntax--link {
     color: @base09;
   }
 
-  &.require {
+  &.syntax--require {
     color: @base0D;
   }
 
-  &.selector {
+  &.syntax--selector {
     color: @base0F;
   }
 
-  &.separator {
+  &.syntax--separator {
     background-color: @base02;
     color: @base06;
   }
 }
 
-.none {
+.syntax--none {
   color: @base06;
 }
 
-.storage {
+.syntax--storage {
   color: @base0D;
 }
 
-.markup {
-  &.heading,
-  &.heading .punctuation.definition.heading {
+.syntax--markup {
+  &.syntax--heading,
+  &.syntax--heading .syntax--punctuation.syntax--definition.syntax--heading {
     color: @base0D;
     font-weight: bolder;
   }
 
-  &.bold {
+  &.syntax--bold {
     color: @base08;
   }
 
-  &.italic {
+  &.syntax--italic {
     color: @base0B;
   }
 
-  &.raw {
+  &.syntax--raw {
     background-color: fadeout(@base02, 80%);
     color: @base0C;
     padding-top: 1px;
   }
 
-  &.changed {
+  &.syntax--changed {
     color: @syntax-color-modified;
   }
 
-  &.deleted {
+  &.syntax--deleted {
     color: @syntax-color-removed;
   }
 
-  &.inserted {
+  &.syntax--inserted {
     color: @syntax-color-added;
   }
-}
-
-atom-text-editor[mini] .scroll-view,
-:host([mini]) .scroll-view {
-  padding-left: 1px;
 }

--- a/styles/languages/css.less
+++ b/styles/languages/css.less
@@ -1,81 +1,81 @@
 // support for CSS as well as SCSS, Sass (indented syntax) and Less
-.source.css,
-.source.scss,
-.source.sass,
-.source.less {
+.syntax--source.syntax--css,
+.syntax--source.syntax--scss,
+.syntax--source.syntax--sass,
+.syntax--source.syntax--less {
 
-  .punctuation {
+  .syntax--punctuation {
     color: @base05;
   }
 
-  .meta {
-    &.brace {
+  .syntax--meta {
+    &.syntax--brace {
       color: @base05;
     }
   }
 
-  .entity {
-    &.name,
-    &.tag {
+  .syntax--entity {
+    &.syntax--name,
+    &.syntax--tag {
       color: @base0D;
     }
 
-    &.reference {
+    &.syntax--reference {
       color: @base0F;
     }
 
-    &.pseudo-class,
-    &.pseudo-element {
+    &.syntax--pseudo-class,
+    &.syntax--pseudo-element {
       color: @base0C;
     }
 
-    &.placeholder {
+    &.syntax--placeholder {
 
-      .punctuation {
+      .syntax--punctuation {
         color: @base06;
       }
     }
   }
 
-  .variable {
-    &.other {
+  .syntax--variable {
+    &.syntax--other {
       color: @base09;
     }
 
-    &.other.less {
+    &.syntax--other.syntax--less {
       color: @base08; // syntax handled differently between less and scss
     }
   }
 
-  .keyword {
+  .syntax--keyword {
 
-    .punctuation {
+    .syntax--punctuation {
       color: @base05;
     }
 
-    &.at-rule {
+    &.syntax--at-rule {
       color: @base0D;
     }
 
-    &.each,
-    &.extend,
-    &.for,
-    &.function,
-    &.include,
-    &.import,
-    &.if,
-    &.mixin,
-    &.return,
-    &.while {
+    &.syntax--each,
+    &.syntax--extend,
+    &.syntax--for,
+    &.syntax--function,
+    &.syntax--include,
+    &.syntax--import,
+    &.syntax--if,
+    &.syntax--mixin,
+    &.syntax--return,
+    &.syntax--while {
       color: @base0E;
     }
 
-    &.important {
+    &.syntax--important {
       color: @base0F;
     }
   }
 
-  .comment {
+  .syntax--comment {
     color: @base04;
   }
 }

--- a/styles/languages/gfm.less
+++ b/styles/languages/gfm.less
@@ -1,64 +1,64 @@
-.source.gfm {
-  .heading-2 {
+.syntax--source.syntax--gfm {
+  .syntax--heading-2 {
     color: mix(@base0D, @base07, 92%)
   }
 
-  .heading-3 {
+  .syntax--heading-3 {
     color: mix(@base0D, @base07, 84%)
   }
 
-  .heading-4 {
+  .syntax--heading-4 {
     color: mix(@base0D, @base07, 76%)
   }
 
-  .heading-5 {
+  .syntax--heading-5 {
     color: mix(@base0D, @base07, 68%)
   }
 
-  .heading-6 {
+  .syntax--heading-6 {
     color: mix(@base0D, @base07, 60%)
   }
 
-  .marker {
+  .syntax--marker {
     color: inherit;
   }
 
-  .link {
+  .syntax--link {
     color: @base0F;
 
-    .punctuation.definition {
+    .syntax--punctuation.syntax--definition {
       color: @base03;
     }
 
-    .entity {
+    .syntax--entity {
       color: @base07;
     }
 
-    .link {
+    .syntax--link {
       color: @base05;
     }
 
-    &.hyperlink {
-      color: @base05;
-    }
-  }
-
-  .bold,
-  .italic {
-    .link {
+    &.syntax--hyperlink {
       color: @base05;
     }
   }
 
-  .list {
+  .syntax--bold,
+  .syntax--italic {
+    .syntax--link {
+      color: @base05;
+    }
+  }
+
+  .syntax--list {
     color: @base0E;
   }
 
-  .quote {
+  .syntax--quote {
     color: @base09;
   }
 
-  .hr {
+  .syntax--hr {
     color: @base0A;
   }
 }

--- a/styles/languages/html.less
+++ b/styles/languages/html.less
@@ -1,13 +1,13 @@
-.html {
-  .punctuation {
+.syntax--html {
+  .syntax--punctuation {
     color: @base05;
   }
 
-  .doctype {
+  .syntax--doctype {
     color: @base0E;
   }
 
-  .comment {
+  .syntax--comment {
     color: @base04;
   }
 }

--- a/styles/languages/javascript.less
+++ b/styles/languages/javascript.less
@@ -1,49 +1,49 @@
-.source.js {
-  .punctuation {
+.syntax--source.syntax--js {
+  .syntax--punctuation {
     color: @base05;
   }
 
-  .keyword.operator {
+  .syntax--keyword.syntax--operator {
     color: @base06;
 
-    &.delete,
-    &.in,
-    &.of,
-    &.instanceof,
-    &.new,
-    &.typeof,
-    &.void {
+    &.syntax--delete,
+    &.syntax--in,
+    &.syntax--of,
+    &.syntax--instanceof,
+    &.syntax--new,
+    &.syntax--typeof,
+    &.syntax--void {
       color: @base0B;
     }
 
-    &.comparison {
+    &.syntax--comparison {
       color: @base0E;
     }
   }
 
-  .entity {
-    &.name.function {
+  .syntax--entity {
+    &.syntax--name.syntax--function {
       color: @base0F;
     }
   }
 
-  .function {
-    &.parameter {
+  .syntax--function {
+    &.syntax--parameter {
       color: @base06;
     }
   }
 
-  .meta {
-    &.brace {
+  .syntax--meta {
+    &.syntax--brace {
       color: @base05;
     }
 
-    &.arguments {
+    &.syntax--arguments {
       color: @base06;
     }
   }
 
-  .comment {
+  .syntax--comment {
     color: @base04;
   }
 }

--- a/styles/languages/json.less
+++ b/styles/languages/json.less
@@ -1,25 +1,25 @@
-.source.json {
-  .dictionary {
-    .string.quoted {
+.syntax--source.syntax--json {
+  .syntax--dictionary {
+    .syntax--string.syntax--quoted {
       color: @base0D;
     }
 
     // value hack until this is better supported in Atom
-    & > .value.json > .string.json {
+    & > .syntax--value.syntax--json > .syntax--string.syntax--json {
       color: @base0B;
     }
   }
 
-  .array {
-    .string.quoted {
+  .syntax--array {
+    .syntax--string.syntax--quoted {
       color: @base0B;
     }
   }
 
-  .punctuation {
+  .syntax--punctuation {
     color: @base05;
 
-    &.key-value {
+    &.syntax--key-value {
       color: @base06;
     }
   }

--- a/styles/languages/liquid.less
+++ b/styles/languages/liquid.less
@@ -1,20 +1,20 @@
-.liquid {
-  .punctuation.liquid {
+.syntax--liquid {
+  .syntax--punctuation.syntax--liquid {
     color: @base05;
   }
 
-  .entity.liquid {
-    &.name,
-    &.tag {
+  .syntax--entity.syntax--liquid {
+    &.syntax--name,
+    &.syntax--tag {
       color: @base0D;
     }
   }
 
-  .class.liquid {
+  .syntax--class.syntax--liquid {
     color: @base08;
   }
 
-  .variable {
+  .syntax--variable {
     color: @base08;
   }
 }

--- a/styles/languages/ruby.less
+++ b/styles/languages/ruby.less
@@ -1,19 +1,19 @@
-.source.ruby {
-  .constant {
-    &.boolean {
+.syntax--source.syntax--ruby {
+  .syntax--constant {
+    &.syntax--boolean {
       color: @base0A;
     }
   }
 
-  .keyword {
-    &.operator {
+  .syntax--keyword {
+    &.syntax--operator {
       color: @base01;
 
-      &.assignment {
+      &.syntax--assignment {
         color: @base0D;
       }
 
-      &.comparison {
+      &.syntax--comparison {
         color: @base0F;
       }
     }

--- a/styles/languages/todo.less
+++ b/styles/languages/todo.less
@@ -1,45 +1,45 @@
-.storage {
-  &.changed,
-  &.fixme,
-  &.hack,
-  &.idea,
-  &.note,
-  &.review,
-  &.todo,
-  &.xxx {
+.syntax--storage {
+  &.syntax--changed,
+  &.syntax--fixme,
+  &.syntax--hack,
+  &.syntax--idea,
+  &.syntax--note,
+  &.syntax--review,
+  &.syntax--todo,
+  &.syntax--xxx {
     font-weight: bolder;
   }
 
-  &.changed {
+  &.syntax--changed {
     color: @base09;
   }
 
-  &.fixme {
+  &.syntax--fixme {
     color: @base08;
   }
 
-  &.hack {
+  &.syntax--hack {
     color: @base0F;
   }
 
-  &.idea {
+  &.syntax--idea {
     color: @base0C;
   }
 
-  &.note,
-  &.nb {
+  &.syntax--note,
+  &.syntax--nb {
     color: @base0D;
   }
 
-  &.review {
+  &.syntax--review {
     color: @base0A;
   }
 
-  &.todo {
+  &.syntax--todo {
     color: @base0B;
   }
 
-  &.xxx {
+  &.syntax--xxx {
     color: @base07;
   }
 }

--- a/styles/languages/yaml.less
+++ b/styles/languages/yaml.less
@@ -1,23 +1,23 @@
-.source.yaml,
-.front-matter.yaml {
-  .string {
+.syntax--source.syntax--yaml,
+.syntax--front-matter.syntax--yaml {
+  .syntax--string {
     color: @base0D;
   }
 
-  .punctuation {
+  .syntax--punctuation {
     color: @base05;
 
-    &.key-value,
-    &.entry {
+    &.syntax--key-value,
+    &.syntax--entry {
       color: @base06;
     }
   }
 
-  .comment {
+  .syntax--comment {
     color: @base04;
   }
 
-  .hyperlink {
+  .syntax--hyperlink {
     color: inherit;
   }
 }


### PR DESCRIPTION
Starting in Atom v1.13.0, there is a new standard for prepending syntax selectors with `.syntax--` and always using `atom-text-editor` instead of `:host`. This is a preemptive fix for that deprecation.

Reported via https://github.com/opattison/newbound-light-syntax/pull/14 and https://github.com/opattison/newbound-light-syntax/issues/13